### PR TITLE
Allow configuring delimiters and HTML escaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _cgo_*
 _obj
 _test
 _testmain.go
+__debug_*
 *.swp
 coverage.txt
 /bin

--- a/baserender.go
+++ b/baserender.go
@@ -1,0 +1,102 @@
+package mustache
+
+// Contains the internal implementation functions for rendering so we can
+// maintain a pretty API.
+
+func render(opts []TemplateOpt, data string, context ...interface{}) (string, error) {
+	return renderRaw(opts, data, false, context...)
+}
+
+// RenderRaw compiles a mustache template string and uses the the given data
+// source - generally a map or struct - to render the template and return the
+// output.
+func renderRaw(opts []TemplateOpt, data string, forceRaw bool, context ...interface{}) (string, error) {
+	return renderPartialsRaw(opts, data, nil, forceRaw, context...)
+}
+
+// RenderPartials compiles a mustache template string and uses the the given partial
+// provider and data source - generally a map or struct - to render the template
+// and return the output.
+func renderPartials(opts []TemplateOpt, data string, partials PartialProvider, context ...interface{}) (string, error) {
+	return renderPartialsRaw(opts, data, partials, false, context...)
+}
+
+// RenderPartialsRaw compiles a mustache template string and uses the the given
+// partial provider and data source - generally a map or struct - to render the
+// template and return the output.
+func renderPartialsRaw(opts []TemplateOpt, data string, partials PartialProvider, forceRaw bool, context ...interface{}) (string, error) {
+	var tmpl *Template
+	var err error
+	if partials == nil {
+		tmpl, err = ParseStringRaw(data, forceRaw, opts...)
+	} else {
+		tmpl, err = ParseStringPartialsRaw(data, partials, forceRaw, opts...)
+	}
+	if err != nil {
+		return "", err
+	}
+	return tmpl.Render(context...)
+}
+
+// RenderInLayout compiles a mustache template string and layout "wrapper" and
+// uses the given data source - generally a map or struct - to render the
+// compiled templates and return the output.
+func renderInLayout(opts []TemplateOpt, data string, layoutData string, context ...interface{}) (string, error) {
+	return renderInLayoutPartials(opts, data, layoutData, nil, context...)
+}
+
+// RenderInLayoutPartials compiles a mustache template string and layout
+// "wrapper" and uses the given data source - generally a map or struct - to
+// render the compiled templates and return the output.
+func renderInLayoutPartials(opts []TemplateOpt, data string, layoutData string, partials PartialProvider, context ...interface{}) (string, error) {
+	var layoutTmpl, tmpl *Template
+	var err error
+	if partials == nil {
+		layoutTmpl, err = ParseString(layoutData, opts...)
+	} else {
+		layoutTmpl, err = ParseStringPartials(layoutData, partials, opts...)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	if partials == nil {
+		tmpl, err = ParseString(data, opts...)
+	} else {
+		tmpl, err = ParseStringPartials(data, partials, opts...)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	return tmpl.RenderInLayout(layoutTmpl, context...)
+}
+
+// RenderFile loads a mustache template string from a file and compiles it, and
+// then uses the given data source - generally a map or struct - to render the
+// template and return the output.
+func renderFile(opts []TemplateOpt, filename string, context ...interface{}) (string, error) {
+	tmpl, err := ParseFile(filename, opts...)
+	if err != nil {
+		return "", err
+	}
+	return tmpl.Render(context...)
+}
+
+// RenderFileInLayout loads a mustache template string and layout "wrapper"
+// template string from files and compiles them, and  then uses the the given
+// data source - generally a map or struct - to render the compiled templates
+// and return the output.
+func renderFileInLayout(opts []TemplateOpt, filename string, layoutFile string, context ...interface{}) (string, error) {
+	layoutTmpl, err := ParseFile(layoutFile, opts...)
+	if err != nil {
+		return "", err
+	}
+
+	tmpl, err := ParseFile(filename, opts...)
+	if err != nil {
+		return "", err
+	}
+	return tmpl.RenderInLayout(layoutTmpl, context...)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cbroglie/mustache
+module github.com/gofixpoint/mustache
 
 go 1.20
 

--- a/optrenderer.go
+++ b/optrenderer.go
@@ -1,0 +1,41 @@
+package mustache
+
+type optRenderer struct {
+	opts []TemplateOpt
+}
+
+func NewRenderer(opts... TemplateOpt) Renderer {
+	return &optRenderer{opts: opts}
+}
+
+func (r *optRenderer) Render(data string, context ...interface{}) (string, error) {
+	return render(r.opts, data, context...)
+}
+
+func (r *optRenderer) RenderRaw(data string, forceRaw bool, context ...interface{}) (string, error) {
+	return renderRaw(r.opts, data, forceRaw, context...)
+}
+
+func (r *optRenderer) RenderPartials(data string, partials PartialProvider, context ...interface{}) (string, error) {
+	return renderPartials(r.opts, data, partials, context...)
+}
+
+func (r *optRenderer) RenderPartialsRaw(data string, partials PartialProvider, forceRaw bool, context ...interface{}) (string, error) {
+	return renderPartialsRaw(r.opts, data, partials, forceRaw, context...)
+}
+
+func (r *optRenderer) RenderInLayout(data string, layoutData string, context ...interface{}) (string, error) {
+	return renderInLayout(r.opts, data, layoutData, context...)
+}
+
+func (r *optRenderer) RenderInLayoutPartials(data string, layoutData string, partials PartialProvider, context ...interface{}) (string, error) {
+	return renderInLayoutPartials(r.opts, data, layoutData, partials, context...)
+}
+
+func (r *optRenderer) RenderFile(filename string, context ...interface{}) (string, error) {
+	return renderFile(r.opts, filename, context...)
+}
+
+func (r *optRenderer) RenderFileInLayout(filename string, layoutFile string, context ...interface{}) (string, error) {
+	return renderFileInLayout(r.opts, filename, layoutFile, context...)
+}

--- a/renderer.go
+++ b/renderer.go
@@ -1,0 +1,44 @@
+package mustache
+
+type Renderer interface {
+	// Render compiles a mustache template string and uses the the given data
+	// source - generally a map or struct - to render the template and return
+	// the output.
+	Render(data string, context ...interface{}) (string, error)
+
+	// RenderRaw compiles a mustache template string and uses the the given data
+	// source - generally a map or struct - to render the template and return
+	// the output.
+	RenderRaw(data string, forceRaw bool, context ...interface{}) (string, error)
+
+	// RenderPartials compiles a mustache template string and uses the the given
+	// partial provider and data source - generally a map or struct - to render
+	// the template and return the output.
+	RenderPartials(data string, partials PartialProvider, context ...interface{}) (string, error)
+
+	// RenderPartialsRaw compiles a mustache template string and uses the the
+	// given partial provider and data source - generally a map or struct - to
+	// render the template and return the output.
+	RenderPartialsRaw(data string, partials PartialProvider, forceRaw bool, context ...interface{}) (string, error)
+
+	// RenderInLayout compiles a mustache template string and layout "wrapper"
+	// and uses the given data source - generally a map or struct - to render
+	// the compiled templates and return the output.
+	RenderInLayout(data string, layoutData string, context ...interface{}) (string, error)
+
+	// RenderInLayoutPartials compiles a mustache template string and layout
+	// "wrapper" and uses the given data source - generally a map or struct - to
+	// render the compiled templates and return the output.
+	RenderInLayoutPartials(data string, layoutData string, partials PartialProvider, context ...interface{}) (string, error)
+
+	// RenderFile loads a mustache template string from a file and compiles it,
+	// and then uses the given data source - generally a map or struct - to
+	// render the template and return the output.
+	RenderFile(filename string, context ...interface{}) (string, error)
+
+	// RenderFileInLayout loads a mustache template string and layout "wrapper"
+	// template string from files and compiles them, and  then uses the the
+	// given data source - generally a map or struct - to render the compiled
+	// templates and return the output.
+	RenderFileInLayout(filename string, layoutFile string, context ...interface{}) (string, error)
+}

--- a/templateopts_test.go
+++ b/templateopts_test.go
@@ -1,0 +1,100 @@
+package mustache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_SingleCurlyBraces(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		tmpl, err := ParseString(
+			"Testing {single_args} curly {braces text}.",
+			WithSingleCurlyTags(),
+		)
+		requireNilError(t, err)
+		txt, err := tmpl.Render(
+			map[string]string{
+				"single_args": "single",
+				"braces text": "braces",
+			},
+		)
+		requireNilError(t, err)
+		requireEqual(t, "Testing single curly braces.", txt)
+	})
+
+	t.Run("escaping HTML", func(t *testing.T) {
+		tmpl, err := ParseString(
+			"Single braces escape HTML by default: {compareTxt}",
+			WithSingleCurlyTags(),
+		)
+		requireNilError(t, err)
+		txt, err := tmpl.Render(map[string]string{"compareTxt": "5 < 10"})
+		requireNilError(t, err)
+		requireEqual(t, "Single braces escape HTML by default: 5 &lt; 10", txt)
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		tmpl, err := ParseString(
+			"Double {{braces}} are raw.",
+			WithSingleCurlyTags(),
+		)
+		requireNilError(t, err)
+		txt, err := tmpl.Render(map[string]string{
+			"braces": "5 < 10",
+		})
+		requireNilError(t, err)
+		requireEqual(t, "Double 5 < 10 are raw.", txt)
+	})
+}
+
+func Test_NoEscaping(t *testing.T) {
+	expected := "We disabled HTML escaping: 5 < 10"
+	args := map[string]string{"compareTxt": "5 < 10"}
+
+	type TestParams struct {
+		input string
+		opts []TemplateOpt
+	}
+	tests := []TestParams{
+		{
+			"We disabled HTML escaping: {{compareTxt}}",
+			[]TemplateOpt{WithHTMLEscape(false)},
+		},
+		{
+			"We disabled HTML escaping: {{{compareTxt}}}",
+			[]TemplateOpt{WithHTMLEscape(false)},
+		},
+		{
+			"We disabled HTML escaping: {compareTxt}",
+			[]TemplateOpt{WithHTMLEscape(false), WithSingleCurlyTags()},
+		},
+		{
+			"We disabled HTML escaping: {{compareTxt}}",
+			[]TemplateOpt{WithHTMLEscape(false), WithSingleCurlyTags()},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("test %d", i), func(t *testing.T) {
+			tmpl, err := ParseString(test.input, test.opts...)
+			requireNilError(t, err)
+			txt, err := tmpl.Render(args)
+			requireNilError(t, err)
+			requireEqual(t, expected, txt)
+		})
+	}
+}
+
+func requireNilError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}
+
+func requireEqual(t *testing.T, expected string, actual string) {
+	t.Helper()
+	if expected != actual {
+		t.Fatalf("Expected \"%s\", got \"%s\"", expected, actual)
+	}
+}


### PR DESCRIPTION
Allow the caller to:

- configure whether to use single or double curly brace delimiters
- whether we escape HTML by default

Also, add a new `Renderer` interface so that we can easily pass through Mustache template options to the render calls while preserving the original `Render*(...)` function APIs.